### PR TITLE
Kubernetes controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-## n-volkov_platform
+# n-volkov_platform
 n-volkov Platform repository
 
 
-### Знакомство с Kubernetes, основные понятия и архитектура
+## Знакомство с Kubernetes, основные понятия и архитектура
 
-- Установлен и запущен Minikube.
-- Настроено рабочее окружение.
+* Установлен и запущен Minikube.
+* Настроено рабочее окружение.
 
 При проведение тестов на устойчивость, на команду:
 
@@ -53,9 +53,12 @@ scheduler            Healthy   ok
 etcd-0               Healthy   {"health":"true"}
 ```
 
-#### Задание
-- Разберитесь почему все pod в namespace kube-system восстановились после удаления.
-##### Ответ
+### Задание
+
+* Разберитесь почему все pod в namespace kube-system восстановились после удаления.
+
+#### Ответ
+
 Pod coredns принадлежит (ownerReferences) контроллеру ReplicaSet.
 
 ```
@@ -77,41 +80,44 @@ Pod kube-proxy принадлежит (ownerReferences) контроллеру D
 
 Остальные pod-ы: etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube и kube-scheduler-minikube, принадлежат узлу (node), и управляются непосредственно kubelet. Kubelet следит за ними, и активирует вновь при падении.
 
-- Был создан Dockerfile, который:
--- запускает web-сервер на порту 8000;
--- отдает содержимое директории /app внутри контейнера;
--- работающий с UID 1001;
-- Dockerfile был помещен в созданную директорию `kubernetes-intro/web`;
-- Из Dockerfile был собран образ контейнера и помещен в публичный Container Registry - Docker Hub;
-- Был написан манифест web-pod.yaml для создания pod **web**, с использованием  ранее собранного образа с Docker Hub. Манифест был помещен в директорию `kubernetes-intro/`;
-- Были опробованы следующие команды:
--- `kubectl apply -f web-pod.yaml`
--- `kubectl get pod web -o yaml`
--- `kubectl describe pod web`
-- В манифест web-pod.yaml было добавлено описание init контейнера, генерирующего страницу index.html;
--- *image* init контейнера содержит wget;
--- *command* init контейнера:  
-`['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh'];`
-- Для того, чтобы файлы, созданные в init контейнере, были доступны основному контейнеру, в манифест было добавлено описание volume типа *emptyDir*;
-- Обновленный pod **web** был запущен, после удаления старого pod:
--- следил за процессом запуска:  
-`kubectl get pods -w`;
--- проверил работоспособность web сервера:  
-`kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`  
-`curl 'http://localhost:8000/index.html'`
+* Был создан Dockerfile, который:
+ * запускает web-сервер на порту 8000;
+ * отдает содержимое директории /app внутри контейнера;
+ * работающий с UID 1001;
+* Dockerfile был помещен в созданную директорию `kubernetes-intro/web`;
+* Из Dockerfile был собран образ контейнера и помещен в публичный Container Registry - Docker Hub;
+* Был написан манифест web-pod.yaml для создания pod **web**, с использованием  ранее собранного образа с Docker Hub. Манифест был помещен в директорию `kubernetes-intro/`;
+* Были опробованы следующие команды:
+ * `$ kubectl apply -f web-pod.yaml`
+ * `$ kubectl get pod web -o yaml`
+ * `$ kubectl describe pod web`
+* В манифест web-pod.yaml было добавлено описание init контейнера, генерирующего страницу index.html;
+ * *image* init контейнера содержит wget;
+ * *command* init контейнера: `['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh'];`
+* Для того, чтобы файлы, созданные в init контейнере, были доступны основному контейнеру, в манифест было добавлено описание volume типа *emptyDir*;
+* Обновленный pod **web** был запущен, после удаления старого pod:
+ * следил за процессом запуска:  
+`$ kubectl get pods -w`;
+ * проверил работоспособность web сервера:  
+`$ kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`  
+`$ curl 'http://localhost:8000/index.html'`
 
-- Знакомство с микросервисным приложением Hipster Shop;
-- Запуск внутри кластера одного его компонента - микросервиса frontend;
--- был сделан клон репозитория `https://github.com/GoogleCloudPlatform/microservices-demo`;
--- собран образ контейнера для frontend из `microservices-demo/src/frontend/Dockerfile`;
--- собранный образ был помещен на Docker Hub;
--- используя ad-hoc режим, был сгенерирован манифест средствами kubectl:  
-`kubectl run frontend --image blackwolf292/kubernetes-intro-frontend:v1 --restart=Never --dry-run=client -o yaml > frontend-pod.yaml`
+* Знакомство с микросервисным приложением Hipster Shop;
+* Запуск внутри кластера одного его компонента - микросервиса frontend;
+ * был сделан клон репозитория `https://github.com/GoogleCloudPlatform/microservices-demo`;
+ * собран образ контейнера для frontend из `microservices-demo/src/frontend/Dockerfile`;
+ * собранный образ был помещен на Docker Hub;
+ * используя ad-hoc режим, был сгенерирован манифест средствами kubectl:  
+`$ kubectl run frontend --image blackwolf292/kubernetes-intro-frontend:v1 --restart=Never --dry-run=client -o yaml > frontend-pod.yaml`
 
-#### Задание
-- Выясните причину, по которой pod frontend находится в статусе Error.
-- Создайте новый манифест frontend-pod-healthy.yaml. При его применении ошибка должна исчезнуть.
+
+### Задание
+
+* Выясните причину, по которой pod frontend находится в статусе Error.
+* Создайте новый манифест frontend-pod-healthy.yaml. При его применении ошибка должна исчезнуть.
+
 #### Ответ
+
 Попытка запуска pod frontend, завершилась ошибкой. Найденная причина - отсутствие описания environment variable в конфигурации контейнера:
 
 ```
@@ -157,3 +163,47 @@ frontend   1/1     Running   0          27s
 ```
 
 И помещен в директорию kubernetes-intro.
+
+## Механика запуска и взаимодействия контейнеров в Kubernetes
+
+* Используя frontend-replicaset.yaml, попытались создать объект ReplicaSet. Получили ошибку.
+
+### Задание
+
+Изменить frontend-replicaset.yaml так, что бы устранить ошибку. И применить его.
+
+#### Ответ
+
+```
+error: error validating "frontend-replicaset.yaml":  
+error validating data: ValidationError(ReplicaSet.spec): missing required field "selector"  
+in io.k8s.api.apps.v1.ReplicaSetSpec
+```
+
+Добавил в манифест поле selector
+
+```
+  selector:
+    matchLabels:
+      app: frontend
+```
+
+* Изменили манифест frontend-replicaset.yaml так, что из него сразу разворачивается 3 реплики сервиса.
+
+* Изменили версию образа в манифесте frontend-replicaset.yaml. Применили манифест.
+
+### Вопрос
+
+Почему обновление ReplicaSet (изменена версия образа контейнера) не повлекло обновление запущенных pod.
+
+#### Ответ
+
+ReplicaSet следит только за тем, что запущено указанное количество pod-ов. Т.к. указанное количество pod-ов уже было запущено, никаких других изменений не произошло.
+
+* Сделал образы для микросервиса paymentService, и залил на Docker Hub. Сделал манифест paymentservice-replicaset.yaml для развертывания трех реплик из образа v1.
+
+* Подготовил и применил Deployment манифест paymentservice-deployment.yaml. В результате чего появилось 3 реплики сервиса payment в состоянии Ready.
+
+* Убедился, на смени версии образа в манифесте Deployment, что работает, как обновление pod, так и откат на предыдущую версию. Увидел, что при обновлении использовалась стратегия по умолчанию - Rolling Update, и наличие двух ReplicaSet.
+
+TODO Probes

--- a/README.md
+++ b/README.md
@@ -201,9 +201,25 @@ in io.k8s.api.apps.v1.ReplicaSetSpec
 ReplicaSet следит только за тем, что запущено указанное количество pod-ов. Т.к. указанное количество pod-ов уже было запущено, никаких других изменений не произошло.
 
 * Сделал образы для микросервиса paymentService, и залил на Docker Hub. Сделал манифест paymentservice-replicaset.yaml для развертывания трех реплик из образа v1.
-
 * Подготовил и применил Deployment манифест paymentservice-deployment.yaml. В результате чего появилось 3 реплики сервиса payment в состоянии Ready.
-
 * Убедился, на смени версии образа в манифесте Deployment, что работает, как обновление pod, так и откат на предыдущую версию. Увидел, что при обновлении использовалась стратегия по умолчанию - Rolling Update, и наличие двух ReplicaSet.
+* Подготовил манифест frontend-deployment.yaml с описанием readinessProbe. Из которого успешно развернул 3 экземпляра pod frontend.
+* Изменил URL проверки readinessProbe на `/_health`. Получил ошибку при применении манифеста:  
+`Readiness probe failed: HTTP probe failed with statuscode: 404`  
+А при использовании команды: `kubectl rollout status deployment frontend-deployment --timeout=60s`, получил:  
+`Waiting for deployment "frontend-deployment" rollout to finish: 1 out of 3 new replicas have been updated...`  `error: timed out waiting for the condition`
 
-TODO Probes
+* Подготовлен манифест node-exporter-daemonset.yaml.
+
+### Задание
+
+Изменить node-exporter-daemonset.yaml так, что бы Node Exporter был развернут не только на worker узлах, но и на master.
+
+#### Ответ
+
+Надо либо отключить политику `Taints: node-role.kubernetes.io/master:NoSchedule` для master узлов, либо дать разрешение pod-ам Node Exporter разворачиваться на master узлах. Например так:
+
+```
+tolerations:
+  operator: "Exists"
+```

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-deployment
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: blackwolf292/kubernetes-intro-frontend:v2
+        name: frontend
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENV_PLATFORM
+          value: "gcp"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: blackwolf292/kubernetes-intro-frontend:v2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+    spec:
+      containers:
+      - args:
+        - --web.listen-address=127.0.0.1:9100
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        - --collector.netdev.device-exclude=^(veth.*)$
+        image: quay.io/prometheus/node-exporter:v1.1.1
+        name: node-exporter
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=[$(IP)]:9100
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: blackwolf292/kubernetes-controllers-paymentservice:v2
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENV_PLATFORM
+          value: "gcp"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: blackwolf292/kubernetes-controllers-paymentservice:v1
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENV_PLATFORM
+          value: "gcp"


### PR DESCRIPTION
### Задание

Изменить frontend-replicaset.yaml так, что бы устранить ошибку. И применить его.

#### Ответ

```
error: error validating "frontend-replicaset.yaml":  
error validating data: ValidationError(ReplicaSet.spec): missing required field "selector"  
in io.k8s.api.apps.v1.ReplicaSetSpec
```

Добавил в манифест поле selector

```
  selector:
    matchLabels:
      app: frontend
```

### Вопрос

Почему обновление ReplicaSet (изменена версия образа контейнера) не повлекло обновление запущенных pod.

#### Ответ

ReplicaSet следит только за тем, что запущено указанное количество pod-ов. Т.к. указанное количество pod-ов уже было запущено, никаких других изменений не произошло.

### Задание

Изменить node-exporter-daemonset.yaml так, что бы Node Exporter был развернут не только на worker узлах, но и на master.

#### Ответ

Надо либо отключить политику `Taints: node-role.kubernetes.io/master:NoSchedule` для master узлов, либо дать разрешение pod-ам Node Exporter разворачиваться на master узлах. Например так:

```
tolerations:
  operator: "Exists"
```
