### PR TITLE
Kubernetes security

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,96 @@ ReplicaSet следит только за тем, что запущено ука
 tolerations:
   operator: "Exists"
 ```
+
+## Что стоит знать о безопасности и управлении доступом в Kubernetes
+
+* Рассмотрена авторизация в Кubernetes на основе RBAC.
+* Созданы манифесты для создания объектов в Кubernetes.
+* Созданы манифесты для управления доступом к Namespaces и к кластеру в целом.
+
+### Task01
+
+1. Создать Service Account **bob**, дать ему роль `admin` в рамках всего кластера;
+2. Создать Service Account **dave** без доступа к кластеру;
+
+В ходе выполнения задания были подготовлены и применены манифесты: `01-sa-bob.yaml`, `02-bob-clusteradmin-rolebinding.yaml`, `03-sa-dave.yaml`.
+
+```
+# kubectl get sa -n default
+NAME            SECRETS   AGE
+bob             1         3m32s
+dave            1         52s
+default         1         3d2h
+ingress-nginx   1         44h
+```
+
+```
+# kubectl get clusterrolebindings bob-rolebinding
+NAME              ROLE                        AGE
+bob-rolebinding   ClusterRole/cluster-admin   13m
+```
+
+### Task02
+
+1. Создать Namespace `prometheus`.
+2. Создать Service Account **carol** в этом Namespace.
+3. Дать всем Service Account в Namespace `prometheus` возможность делать *get*, *list*, *watch* в отношении Pods всего кластера.
+
+В ходе выполнения задания были подготовлены и применены манифесты: `01-ns-prometheus.yaml`, `02-sa-carol.yaml`, `03-pod-info-role.yaml`, `04-pod-info-rolebinding.yaml`.
+
+```
+# kubectl get ns prometheus
+NAME         STATUS   AGE
+prometheus   Active   3h27m
+```
+
+```
+# kubectl get sa -n prometheus
+NAME      SECRETS   AGE
+carol     1         3h30m
+default   1         3h33m
+```
+
+```
+# kubectl get clusterrole pod-info
+NAME       CREATED AT
+pod-info   2021-04-13T12:02:30Z
+```
+
+```
+# kubectl get clusterrolebindings -n prometheus pod-info-rolebinding
+NAME                   ROLE                   AGE
+pod-info-rolebinding   ClusterRole/pod-info   172m
+```
+
+### Task03
+
+1. Создать Namespace `dev`
+2. Создать Service Account **jane** в Namespace `dev`
+3. Дать **jane** роль *admin* в рамках Namespace `dev`
+4. Создать Service Account **ken** в Namespace `dev`
+5. Дать **ken** роль *view* в рамках Namespace `dev`
+
+
+В ходе выполнения задания были подготовлены и применены манифесты: `01-ns-dev.yaml`, `02-sa-jane.yaml`, `03-jane-admin-rolebinding.yaml`, `04-sa-ken.yaml`, `05-ken-view-rolebinding.yaml`.
+
+```
+# kubectl get ns dev
+NAME   STATUS   AGE
+dev    Active   3s
+```
+
+```
+# kubectl get sa -n dev
+NAME      SECRETS   AGE
+default   1         119s
+jane      1         81s
+ken       1         4s
+```
+
+```
+# kubectl get rolebindings -n dev
+NAME                     ROLE                AGE
+jane-admin-rolebinding   ClusterRole/admin   21s
+ken-view-rolebinding     ClusterRole/view    6s
+```

--- a/kubernetes-security/task01/01-sa-bob.yaml
+++ b/kubernetes-security/task01/01-sa-bob.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bob
+  namespace: default

--- a/kubernetes-security/task01/02-bob-clusteradmin-rolebinding.yaml
+++ b/kubernetes-security/task01/02-bob-clusteradmin-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: bob
-  apiGroup: rbac.authorization.k8s.io
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/kubernetes-security/task01/02-bob-clusteradmin-rolebinding.yaml
+++ b/kubernetes-security/task01/02-bob-clusteradmin-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bob-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: bob
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/task01/03-sa-dave.yaml
+++ b/kubernetes-security/task01/03-sa-dave.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dave
+  namespace: default

--- a/kubernetes-security/task02/01-ns-prometheus.yaml
+++ b/kubernetes-security/task02/01-ns-prometheus.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus

--- a/kubernetes-security/task02/02-sa-carol.yaml
+++ b/kubernetes-security/task02/02-sa-carol.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: carol
+  namespace: prometheus

--- a/kubernetes-security/task02/03-pod-info-role.yaml
+++ b/kubernetes-security/task02/03-pod-info-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-info
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/kubernetes-security/task02/04-pod-info-rolebinding.yaml
+++ b/kubernetes-security/task02/04-pod-info-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-info-rolebinding
+subjects:
+  - kind: Group
+    name: system:serviceaccounts:prometheus
+    namespace: prometheus
+roleRef:
+  kind: ClusterRole
+  name: pod-info
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/task03/01-ns-dev.yaml
+++ b/kubernetes-security/task03/01-ns-dev.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes-security/task03/02-sa-jane.yaml
+++ b/kubernetes-security/task03/02-sa-jane.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jane
+  namespace: dev

--- a/kubernetes-security/task03/03-jane-admin-rolebinding.yaml
+++ b/kubernetes-security/task03/03-jane-admin-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jane-admin-rolebinding
+  namespace: dev
+subjects:
+- kind: ServiceAccount
+  name: jane
+  namespace: dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/task03/04-sa-ken.yaml
+++ b/kubernetes-security/task03/04-sa-ken.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ken
+  namespace: dev

--- a/kubernetes-security/task03/05-ken-view-rolebinding.yaml
+++ b/kubernetes-security/task03/05-ken-view-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ken-view-rolebinding
+  namespace: dev
+subjects:
+  - kind: ServiceAccount
+    name: ken
+    namespace: dev
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Что стоит знать о безопасности и управлении доступом в Kubernetes

* Рассмотрена авторизация в Кubernetes на основе RBAC.
* Созданы манифесты для создания объектов в Кubernetes.
* Созданы манифесты для управления доступом к Namespaces и к кластеру в целом.

### Task01

1. Создать Service Account **bob**, дать ему роль `admin` в рамках всего кластера;
2. Создать Service Account **dave** без доступа к кластеру;

В ходе выполнения задания были подготовлены и применены манифесты: `01-sa-bob.yaml`, `02-bob-clusteradmin-rolebinding.yaml`, `03-sa-dave.yaml`.

```
# kubectl get sa -n default
NAME            SECRETS   AGE
bob             1         3m32s
dave            1         52s
default         1         3d2h
ingress-nginx   1         44h
```

```
# kubectl get clusterrolebindings bob-rolebinding
NAME              ROLE                        AGE
bob-rolebinding   ClusterRole/cluster-admin   13m
```

### Task02

1. Создать Namespace `prometheus`.
2. Создать Service Account **carol** в этом Namespace.
3. Дать всем Service Account в Namespace `prometheus` возможность делать *get*, *list*, *watch* в отношении Pods всего кластера.

В ходе выполнения задания были подготовлены и применены манифесты: `01-ns-prometheus.yaml`, `02-sa-carol.yaml`, `03-pod-info-role.yaml`, `04-pod-info-rolebinding.yaml`.

```
# kubectl get ns prometheus
NAME         STATUS   AGE
prometheus   Active   3h27m
```

```
# kubectl get sa -n prometheus
NAME      SECRETS   AGE
carol     1         3h30m
default   1         3h33m
```

```
# kubectl get clusterrole pod-info
NAME       CREATED AT
pod-info   2021-04-13T12:02:30Z
```

```
# kubectl get clusterrolebindings -n prometheus pod-info-rolebinding
NAME                   ROLE                   AGE
pod-info-rolebinding   ClusterRole/pod-info   172m
```

### Task03

1. Создать Namespace `dev`
2. Создать Service Account **jane** в Namespace `dev`
3. Дать **jane** роль *admin* в рамках Namespace `dev`
4. Создать Service Account **ken** в Namespace `dev`
5. Дать **ken** роль *view* в рамках Namespace `dev`


В ходе выполнения задания были подготовлены и применены манифесты: `01-ns-dev.yaml`, `02-sa-jane.yaml`, `03-jane-admin-rolebinding.yaml`, `04-sa-ken.yaml`, `05-ken-view-rolebinding.yaml`.

```
# kubectl get ns dev
NAME   STATUS   AGE
dev    Active   3s
```

```
# kubectl get sa -n dev
NAME      SECRETS   AGE
default   1         119s
jane      1         81s
ken       1         4s
```

```
# kubectl get rolebindings -n dev
NAME                     ROLE                AGE
jane-admin-rolebinding   ClusterRole/admin   21s
ken-view-rolebinding     ClusterRole/view    6s
```
