### PR TITLE
Kubernetes volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,3 +316,46 @@ NAME                     ROLE                AGE
 jane-admin-rolebinding   ClusterRole/admin   21s
 ken-view-rolebinding     ClusterRole/view    6s
 ```
+
+## Volumes, Storages, Stateful приложения
+
+* С помощью инструмента Kind, поднят одноузловый кластер K8S.
+* Развернут StatefulSet с MinIO, и создан Headless Service. Для чего были созданы манифесты: `minio-statefulset.yaml`, `minio-headless-service.yaml`.
+
+```
+$ kubectl get statefulsets minio
+NAME    READY   AGE
+minio   1/1     24m
+```
+
+```
+$ kubectl get pods minio-0
+NAME      READY   STATUS    RESTARTS   AGE
+minio-0   1/1     Running   0          23m
+```
+
+```
+$ kubectl get service minio
+NAME    TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+minio   ClusterIP   None         <none>        9000/TCP   4h20m
+```
+
+```
+$ kubectl get pvc
+NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-minio-0   Bound    pvc-da9cc2ed-5206-4b98-be93-42a02bd4dc8f   10Gi       RWO            standard       24m
+```
+
+```
+$ kubectl get pv
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
+pvc-da9cc2ed-5206-4b98-be93-42a02bd4dc8f   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                24m
+```
+
+* Затем, для повышения безопасности, изменил манифест `minio-statefulset.yaml` на использование *secrets*. Для чего был создан манифест `minio-secret.yaml`.
+
+```
+$ kubectl get secrets minio-secret
+NAME           TYPE     DATA   AGE
+minio-secret   Opaque   2      24m
+```

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secret.yaml
+++ b/kubernetes-volumes/minio-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+type: Opaque
+data:
+  minio_access_key: bWluaW8=
+  minio_secret_key: bWluaW8xMjM=

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secret
+              key: minio_access_key
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secret
+              key: minio_secret_key
+        image: minio/minio:RELEASE.2021-04-06T23-11-00Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
* С помощью инструмента Kind, поднят одноузловый кластер K8S.
* Развернут StatefulSet с MinIO, и создан Headless Service. Для чего были созданы манифесты: `minio-statefulset.yaml`, `minio-headless-service.yaml`.

```
$ kubectl get statefulsets minio
NAME    READY   AGE
minio   1/1     24m
```

```
$ kubectl get pods minio-0
NAME      READY   STATUS    RESTARTS   AGE
minio-0   1/1     Running   0          23m
```

```
$ kubectl get service minio
NAME    TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
minio   ClusterIP   None         <none>        9000/TCP   4h20m
```

```
$ kubectl get pvc
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-minio-0   Bound    pvc-da9cc2ed-5206-4b98-be93-42a02bd4dc8f   10Gi       RWO            standard       24m
```

```
$ kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
pvc-da9cc2ed-5206-4b98-be93-42a02bd4dc8f   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                24m
```

* Затем, для повышения безопасности, изменил манифест `minio-statefulset.yaml` на использование *secrets*. Для чего был создан манифест `minio-secret.yaml`.

```
$ kubectl get secrets minio-secret
NAME           TYPE     DATA   AGE
minio-secret   Opaque   2      24m
```
